### PR TITLE
fixes typo for stats-optout

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const help = require('./lib/help')
 
 const botkitDefaults = {
   debug: false,
-  status_optout: true,
+  stats_optout: true,
   logger: require('skellington-logger')('botkit')
 }
 

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -108,7 +108,7 @@ describe('Skellington', function () {
 
     it('should pass botkit config to botkit with defaults', function () {
       const expectedConfg = _.clone(testConfig.botkit)
-      expectedConfg.status_optout = true
+      expectedConfg.stats_optout = true
       expectedConfg.debug = false
       expectedConfg.logger = skellingtonLoggerMock('botkit')
 
@@ -119,7 +119,7 @@ describe('Skellington', function () {
     it('should pass defaults to botkit if no botkit config is passed', function () {
       const expectedConfg = {
         debug: false,
-        status_optout: true,
+        stats_optout: true,
         logger: skellingtonLoggerMock('botkit')
       }
 


### PR DESCRIPTION
ugh... dumb typo wasn't actually opting out of stats collection. 

If someone explicitly passed `stats_optout`, they would have been opted out of stats. This just affects the defaults.