### PR TITLE
adds startRtm option for slack apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Adds `startRtm` option for Slack apps. If `startRtm` is strictly false Skellington will not initiate an RTM connection when adding a new bot.
-This means that the `botConnected` lifecycle method will never be called.
+Setting `startRtm` to false also means that the `botConnected` lifecycle method will never be called.
 
 ## [1.2.0](https://github.com/Skellington-Closet/skellington/compare/v1.1.2...v1.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.0](https://github.com/Skellington-Closet/skellington/compare/v1.2.0...v1.3.0)
+
+### Added
+
+- Adds `startRtm` option for Slack apps. If `startRtm` is strictly false Skellington will not initiate an RTM connection when adding a new bot.
+This means that the `botConnected` lifecycle method will never be called.
+
 ## [1.2.0](https://github.com/Skellington-Closet/skellington/compare/v1.1.2...v1.2.0)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ to verify the callback from the Identity Provider (Slack, in this case) is legit
 
 - `scopes` (Array) The [OAuth scopes](https://api.slack.com/docs/oauth-scopes) your app will be requesting. Defaults to no scopes. Scopes can be passed from plugins as well.
 
+- `startRtm` (Boolean) Defaults to `true`. If strictly false Skellington will not initiate an RTM connection when adding a new bot.
+Setting `startRtm` false is good for Slack apps that will rely solely on the Events API for events. NOTE: When `startRtm` is 
+false the `botConnected` lifecycle method will never be called.
+
 - `successRedirectUri` (String) A URI to for Skellington to redirect to after a successful OAuth
 authentication flow.
 
@@ -162,7 +166,7 @@ and the bot. `botConnected` can be used for building a cache of team specific en
 information about a team you could need.
 
 `botConnected` is called for single team bots and Slack apps, though for single team bots it is called at the same moment
-in the lifecycle as `init`.
+in the lifecycle as `init`. If `startRtm` is false for a Slack app, then this lifecycle method will never be called.
 
 It is only fired if the RTM session can be established unlike the Botkit `create_bot` event, which is called after a successful OAuth
 authorization flow, but before an RTM session is established.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ and the bot. `botConnected` can be used for building a cache of team specific en
 information about a team you could need.
 
 `botConnected` is called for single team bots and Slack apps, though for single team bots it is called at the same moment
-in the lifecycle as `init`. If `startRtm` is false for a Slack app, then this lifecycle method will never be called.
+in the lifecycle as `init`. If `startRtm` is false for a Slack app then this lifecycle method will never be called.
 
 It is only fired if the RTM session can be established unlike the Botkit `create_bot` event, which is called after a successful OAuth
 authorization flow, but before an RTM session is established.

--- a/lib/slack-app.js
+++ b/lib/slack-app.js
@@ -22,20 +22,22 @@ module.exports.start = (controller, config) => {
 
   lifecycle.initialize(config.plugins, controller, null)
 
-  controller.storage.teams.all((err, teams) => {
-    if (err) {
-      logger.error(`Could not reconnect teams`, err)
-      return process.exit(1)
-    }
+  if (config.startRtm !== false) {
+    controller.storage.teams.all((err, teams) => {
+      if (err) {
+        logger.error(`Could not reconnect teams`, err)
+        return process.exit(1)
+      }
 
-    _.forEach(teams, (team) => {
-      if (!team.bot) return
-      controller.spawn(team).startRTM(_.partial(onStartRtm, controller, config, team))
+      _.forEach(teams, (team) => {
+        if (!team.bot) return
+        controller.spawn(team).startRTM(_.partial(onStartRtm, controller, config, team))
+      })
     })
-  })
 
-  controller.on('create_bot', _.partial(createBot, controller, config))
-  controller.on('rtm_reconnect_failed', (bot, err) => rtmReconnectFailed(config, bot, err))
+    controller.on('create_bot', _.partial(createBot, controller, config))
+    controller.on('rtm_reconnect_failed', (bot, err) => rtmReconnectFailed(config, bot, err))
+  }
 }
 
 function createBot (controller, config, bot) {

--- a/test/unit/lib/slack-app.spec.js
+++ b/test/unit/lib/slack-app.spec.js
@@ -175,6 +175,14 @@ describe('slack-app', function () {
     expect(lifecycleMock.botConnected).not.to.have.been.called()
   })
 
+  it('should not read teams for storage or add event listeners when isRtm is strictly false', function () {
+    testConfig.startRtm = false
+    slackApp.start(controllerMock, testConfig)
+
+    expect(controllerMock.spawn).not.to.have.been.called()
+    expect(controllerMock.on).not.to.have.been.called()
+  })
+
   describe('event: create_bot', function () {
     let callback
     let testConfig


### PR DESCRIPTION
Setting startRtm to strictly `false` will cause Skellington to not start an RTM connection for new teams or teams added from storage.

This is useful for creating a Slack app that uses the Events API. If events are coming from both the Events API and the RTM API, the bot will receive duplicate messages and process them more than once.